### PR TITLE
python-utility-api-auth: Updated API Utility to allow for x-api-key header

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,35 @@ dynamodb_table = "example-terraform-state-lock-table" # DynamoDB table managing 
 
 ***terraform.tfvars*** - All terraform variables should be populated here.
 ```
-example_variable = "example_value"
+account_id = "1234567891012" # Your AWS Account ID
+
+processing_bucket = {
+  name          = "eventpulse-processing-bucket"
+  region        = "us-east-1"
+  force_destroy = true
+}
+
+quarantine_bucket = {
+  name          = "eventpulse-quarantine-bucket"
+  region        = "us-east-1"
+  force_destroy = true
+}
+
+dynamodb_table = {
+  name      = "event-pulse-table"
+  hash_key  = "ArtistID"
+  range_key = "ItemID"
+}
+
+sns_configuration = {
+  name          = "eventpulse_sns_alert_topic"
+  email_address = "justinchunng@gmail.com" # Your email for SNS alerts
+}
+
+iam_authenticated_user_configuration = {
+  user_name = "user" # Your IAM user name
+}
+
 ```
 
 When properly configured, run `terraform init -backend-config=backend.conf` to initialize the state file into the S3 bucket.  Then run `terraform apply` to provision the resources.

--- a/docs/report/index.md
+++ b/docs/report/index.md
@@ -608,3 +608,11 @@ After confirming authorization, I had to update the architectural diagram to ref
 The final improvement made was to update the `api_query.py` utility script to include the API key in the request headers.  The script was updated to pull the API key from the SSM parameter store using the boto3 SSM client.  The API key is then included in the headers of the GET request to the API Gateway endpoint.
 
 When testing the updated script, I was able to successfully query the API Gateway using the API key for authorization.  The only problem that I ran into was that the role was originally not authorized to read from SSM.  To fix this, I updated the IAM policy attached to the authenticated user to include the `ssm:GetParameter` action.  After doing so, the script was able to retrieve the API key from SSM and make authorized requests to the API Gateway!
+
+## Conclusion
+
+This project has been a comprehensive exercise in building a serverless application using AWS services and Terraform.  The initial requirements were met, and several improvements were made to enhance security, functionality, and maintainability.  The use of Terraform allowed for infrastructure as code, making it easier to manage and version control the AWS resources.  The Python scripts provided utility functions for interacting with the AWS services, facilitating testing and user interactions. I encountered several challenges along the way, particularly with IAM permissions and API Gateway configurations.  However, these challenges provided valuable learning experiences and insights into best practices for AWS architecture and security.  Overall, this project has been a successful demonstration of building a serverless application with AWS and Terraform, and it serves as a solid foundation for future enhancements and features.
+
+If you made it this far, thank you for reading!  I hope this documentation has been helpful in understanding the project and its components.  If you have any questions or feedback, please feel free to reach out in the links provided within the [README.md](../../README.md) at the bottom.
+
+Keep on building in the cloud!

--- a/docs/report/index.md
+++ b/docs/report/index.md
@@ -602,3 +602,9 @@ I still ran into 500 issues after making the change.  I then checked back to the
 <img src="./img/postman-auth-success.jpg" alt="postman-auth-success"/>
 
 After confirming authorization, I had to update the architectural diagram to reflect the changes made.  The diagram now includes the API Gateway authorizer Lambda function and the SSM parameter store for the API key.
+
+### Python Utility - API Query Tool Update
+
+The final improvement made was to update the `api_query.py` utility script to include the API key in the request headers.  The script was updated to pull the API key from the SSM parameter store using the boto3 SSM client.  The API key is then included in the headers of the GET request to the API Gateway endpoint.
+
+When testing the updated script, I was able to successfully query the API Gateway using the API key for authorization.  The only problem that I ran into was that the role was originally not authorized to read from SSM.  To fix this, I updated the IAM policy attached to the authenticated user to include the `ssm:GetParameter` action.  After doing so, the script was able to retrieve the API key from SSM and make authorized requests to the API Gateway!

--- a/scripts/utilities/api_query/api_query.py
+++ b/scripts/utilities/api_query/api_query.py
@@ -1,8 +1,11 @@
 # This script was created to make API queries with the API Gateway created.
 
+import boto3
 import requests
 import json
 import click
+
+from ..reusable.sts_get_credentials import get_credentials
 
 def make_api_query(endpoint, params=None, headers=None):
     """Make a GET request to the API endpoint."""
@@ -19,8 +22,37 @@ def make_api_query(endpoint, params=None, headers=None):
 @click.option("--attributes", default=None, help="Attributes to filter the response of the API query (comma-separated).")
 def main(artist_id, item_id, attributes):
     """Query the EventPulse API Gateway."""
-    # Replace the value of the invoke URL by running `terraform output` and copying the value of `api_invoke_url`
-    invoke_url = "https://jz7eq1qnk8.execute-api.us-east-1.amazonaws.com/v1/items"
+
+    # Configurations - Run `terraform output` to get the configurations
+    invoke_url = "https://jz7eq1qnk8.execute-api.us-east-1.amazonaws.com/v1/items" # `api_invoke_url` value
+    ssm_parameter = "/eventpulse/api_gateway/api_key" # `ssm_api_key_parameter_name` value
+    iam_role = "arn:aws:iam::1234567891012:role/eventpulse_authenticated_user_role" # Replace with your IAM role ARN
+    iam_role = "arn:aws:iam::796973511517:role/eventpulse_authenticated_user_role"
+
+    credentials = get_credentials(iam_role)
+
+
+    if credentials is None:
+        print("Could not assume role, exiting.")
+        return
+
+    ssm_client = boto3.client("ssm",
+                              aws_access_key_id=credentials['AccessKeyId'],
+                              aws_secret_access_key=credentials['SecretAccessKey'],
+                              aws_session_token=credentials['SessionToken'],
+                              region_name="us-east-1")
+
+    ssm_parameter_value = None
+
+    try:
+        response = ssm_client.get_parameter(
+            Name=ssm_parameter,
+            WithDecryption=True
+        )
+        ssm_parameter_value = response['Parameter']['Value']
+    except Exception as e:
+        print(f"Error retrieving SSM parameter: {e}")
+        return
 
     # Build query parameters
     params = {"artist_id": artist_id}
@@ -33,7 +65,9 @@ def main(artist_id, item_id, attributes):
 
     print(f"Querying API with params: {params}")
 
-    response = make_api_query(invoke_url, params=params)
+    headers = {"x-api-key": ssm_parameter_value}
+
+    response = make_api_query(invoke_url, params=params, headers=headers)
 
     if response:
         print("\nAPI Response:")

--- a/scripts/utilities/api_query/api_query.py
+++ b/scripts/utilities/api_query/api_query.py
@@ -27,7 +27,6 @@ def main(artist_id, item_id, attributes):
     invoke_url = "https://jz7eq1qnk8.execute-api.us-east-1.amazonaws.com/v1/items" # `api_invoke_url` value
     ssm_parameter = "/eventpulse/api_gateway/api_key" # `ssm_api_key_parameter_name` value
     iam_role = "arn:aws:iam::1234567891012:role/eventpulse_authenticated_user_role" # Replace with your IAM role ARN
-    iam_role = "arn:aws:iam::796973511517:role/eventpulse_authenticated_user_role"
 
     credentials = get_credentials(iam_role)
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -100,4 +100,5 @@
 | <a name="output_authenticated_user_role_arn"></a> [authenticated\_user\_role\_arn](#output\_authenticated\_user\_role\_arn) | ARN of the IAM role for authenticated user to assume |
 | <a name="output_processing_bucket_name"></a> [processing\_bucket\_name](#output\_processing\_bucket\_name) | Name of the S3 processing bucket |
 | <a name="output_quarantine_bucket_name"></a> [quarantine\_bucket\_name](#output\_quarantine\_bucket\_name) | Name of the S3 quarantine bucket |
+| <a name="output_ssm_api_key_parameter_name"></a> [ssm\_api\_key\_parameter\_name](#output\_ssm\_api\_key\_parameter\_name) | The name of the SSM Parameter Store entry for the API Key |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -52,6 +52,13 @@ resource "aws_iam_policy" "authenticated_user_policy" {
           aws_s3_bucket.quarantine_bucket.arn,
           "${aws_s3_bucket.quarantine_bucket.arn}/*"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter"
+        ]
+        Resource = aws_ssm_parameter.api_key_parameter.arn
       }
     ]
   })

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -19,3 +19,8 @@ output "api_invoke_url" {
   description = "The API invoke URL for the API Gateway"
   value       = "${aws_apigatewayv2_stage.lambda.invoke_url}/items"
 }
+
+output "ssm_api_key_parameter_name" {
+  description = "The name of the SSM Parameter Store entry for the API Key"
+  value       = aws_ssm_parameter.api_key_parameter.name
+}


### PR DESCRIPTION
This PR updates the Python Utility to Support the new authorization done in the previous PR.  The script had to be updated to retrieve the SSM parameter store value and can now be used in the `x-api-key` header value.  To get the SSM value, we needed to authenticate using the IAM role and create an SSM boto3 client.

[1] - Previous PR: https://github.com/jcng75/EventPulse/pull/17